### PR TITLE
Pokemon list display shows Pokemon names instead of class info

### DIFF
--- a/lib/simulation.rb
+++ b/lib/simulation.rb
@@ -38,9 +38,9 @@ class Simulation
 
   def announce_teams
     puts "\nTEAM 1:"
-    @team1.pokemon.each { |pokemon| puts pokemon }
+    @team1.pokemon.each { |pokemon| puts pokemon.name }
     puts "\nTEAM 2:"
-    @team2.pokemon.each { |pokemon| puts pokemon }
+    @team2.pokemon.each { |pokemon| puts pokemon.name }
   end
 
   def set_opponents

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -38,14 +38,8 @@ class Team
   end
 
   def switch_pokemon
-    # Show current pokemon
-    puts "\nSwitching #{@active_pokemon} for..."
     available_pokemon = @pokemon - [@active_pokemon]
-
-    # Update current pokemon
-    list_options(available_pokemon)
-    user_choice = (gets.chomp.to_i - 1)
-    @active_pokemon = available_pokemon[user_choice]
+    @active_pokemon = TTY::Prompt.new.select("Switching #{@active_pokemon.name} for...", available_pokemon.collect { |pokemon| pokemon.name } )
     puts "#{@active_pokemon.upcase}!"
   end
 end


### PR DESCRIPTION
Fixes: #4

A few spots were missing .name since we changed the list of pokemon from strings to class instances. Also added the new TTY-prompt select menu for the `switch` method.